### PR TITLE
Add Elm 0.18 backward compatibility

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.18.0",
+  "summary": "Use Webpack-powered asset loading inside your Elm views (Elm 0.18 release)",
+  "repository": "https://github.com/cultureamp/babel-elm-assets-plugin.git",
+  "license": "MIT",
+  "source-directories": ["src"],
+  "exposed-modules": ["WebpackAsset"],
+  "dependencies": {
+      "elm-lang/core": "5.0.0 <= v < 6.0.0"
+  },
+  "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,12 +1,16 @@
 {
-  "version": "0.18.0",
-  "summary": "Use Webpack-powered asset loading inside your Elm views (Elm 0.18 release)",
-  "repository": "https://github.com/cultureamp/babel-elm-assets-plugin.git",
-  "license": "MIT",
-  "source-directories": ["src"],
-  "exposed-modules": ["WebpackAsset"],
-  "dependencies": {
-      "elm-lang/core": "5.0.0 <= v < 6.0.0"
-  },
-  "elm-version": "0.18.0 <= v < 0.19.0"
+    "version": "1.0.1",
+    "summary": "Use Webpack-powered asset loading inside your Elm views (Elm 0.18 release)",
+    "repository": "https://github.com/cultureamp/babel-elm-assets-plugin.git",
+    "license": "MIT",
+    "source-directories": [
+        "src"
+    ],
+    "exposed-modules": [
+        "WebpackAsset"
+    ],
+    "dependencies": {
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm.json
+++ b/elm.json
@@ -1,13 +1,15 @@
 {
-  "type": "package",
-  "name": "cultureamp/babel-elm-assets-plugin",
-  "summary": "Use Webpack-powered asset loading inside your Elm views",
-  "license": "MIT",
-  "version": "1.0.0",
-  "exposed-modules": ["WebpackAsset"],
-  "elm-version": "0.19.0 <= v < 0.20.0",
-  "dependencies": {
-    "elm/core": "1.0.0 <= v < 2.0.0"
-  },
-  "test-dependencies": {}
+    "type": "package",
+    "name": "cultureamp/babel-elm-assets-plugin",
+    "summary": "Use Webpack-powered asset loading inside your Elm views",
+    "license": "MIT",
+    "version": "1.0.1",
+    "exposed-modules": [
+        "WebpackAsset"
+    ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/core": "1.0.0 <= v < 2.0.0"
+    },
+    "test-dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "prepublish": "yarn build && yarn test"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.1",

--- a/src/WebpackAsset.elm
+++ b/src/WebpackAsset.elm
@@ -2,8 +2,10 @@ module WebpackAsset exposing (AssetUrl, assetUrl)
 
 {-| This library lets you reference webpack assets in your Elm views,
 and have them replaced with require() statements (and eventually, the URLs
-of the assets) at compile time. Designed to be used with the corresponding
-Babel plugin.
+of the assets) at compile time.
+
+Designed to be used with the corresponding babel-elm-assets-plugin.
+See https://github.com/cultureamp/babel-elm-assets-plugin
 
 @docs AssetUrl
 @docs assetUrl

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,10 @@ const isAssetExpression = (
     options.module.replace(/\./g, "$"),
     options.function
   ].join("$");
-  return (
-    isIdentifier(expression.callee) && expression.callee.name === taggerName
+  return ["", "_"].some(
+    prefix =>
+      isIdentifier(expression.callee) &&
+      expression.callee.name === prefix + taggerName
   );
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,14 @@ const defaultPluginOptions: PluginOptions = {
 
 const plugin = ({}): PluginObj => {
   /** An append-only list of error descriptions. */
-  const errors: string[] = [];
+  let errors: string[] = [];
   const name = "babel-elm-assets-plugin";
 
   return {
     name,
+    pre: () => {
+      errors = []
+    },
     post: () => {
       if (errors.length > 0) {
         // report errors and throw

--- a/test/__snapshots__/plugin.spec.ts.snap
+++ b/test/__snapshots__/plugin.spec.ts.snap
@@ -4494,3 +4494,5 @@ exports[`the plugin transforms a fully compiled optimized build 1`] = `
   });
 })(this);"
 `;
+
+exports[`the plugin works with Elm 0.18 generated code 1`] = `"require('ca-assets/images/illustrations/dashboard.svg').__esModule ? require('ca-assets/images/illustrations/dashboard.svg').default : require('ca-assets/images/illustrations/dashboard.svg');"`;

--- a/test/fixtures/elm18_input.js
+++ b/test/fixtures/elm18_input.js
@@ -1,0 +1,1 @@
+_cultureamp$babel_elm_assets_plugin$WebpackAsset$assetUrl('ca-assets/images/illustrations/dashboard.svg')

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -46,4 +46,11 @@ describe("the plugin", () => {
       "When using WebpackAsset.assetUrl (from cultureamp/babel-elm-assets-plugin) you must provide the asset path as a constant string";
     expect(() => transform(input)).toThrow(expectedError);
   });
+
+  it("works with Elm 0.18 generated code", () => {
+    const transform = transformWith(plugin)
+    const input = fixture("elm18_input.js");
+    console.log(input);
+    expect(transform(input)).toMatchSnapshot()
+  });
 });

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -50,7 +50,6 @@ describe("the plugin", () => {
   it("works with Elm 0.18 generated code", () => {
     const transform = transformWith(plugin)
     const input = fixture("elm18_input.js");
-    console.log(input);
     expect(transform(input)).toMatchSnapshot()
   });
 });


### PR DESCRIPTION
- Add an `elm-package.json`
- Make an arbitrary documentation change so that Elm will let me bump and publish a new version
- Update the loader to support an `_` in the function name, which was what Elm 0.18 did
- Add a test for Elm 0.18 syntax
- Fix an issue where errors were persisting between tests, causing failures
- Add a pre-publish script to ensure we don't publish an old version by accident (🤦‍♂)

Please note, I've already published the Elm package (no changes were required other than adding the elm-package.json). The NPM package will need a version bump and publish.