### PR TITLE
Fix Elm 18 support when the module you configure is nested

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,16 +80,17 @@ const isAssetExpression = (
   expression: CallExpression,
   options: PluginOptions
 ) => {
-  const taggerName = [
+  const elm18TaggerName = [
+    "_" + options.package.replace(/-/g, "_").replace(/\//g, "$"),
+    options.module.replace(/\./g, "_"),
+    options.function
+  ].join("$")
+  const elm19TaggerName = [
     options.package.replace(/-/g, "_").replace(/\//g, "$"),
     options.module.replace(/\./g, "$"),
     options.function
   ].join("$");
-  return ["", "_"].some(
-    prefix =>
-      isIdentifier(expression.callee) &&
-      expression.callee.name === prefix + taggerName
-  );
+  return isIdentifier(expression.callee) && (expression.callee.name == elm18TaggerName || expression.callee.name == elm19TaggerName)
 };
 
 export default plugin;

--- a/test/__snapshots__/plugin.spec.ts.snap
+++ b/test/__snapshots__/plugin.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`the plugin custom options work with Elm 0.18 1`] = `"require('@cultureamp/kaizen-component-library/icons/academy.svg').__esModule ? require('@cultureamp/kaizen-component-library/icons/academy.svg').default : require('@cultureamp/kaizen-component-library/icons/academy.svg');"`;
+
 exports[`the plugin transforms a fully compiled optimized build 1`] = `
 "(function (scope) {
   'use strict';

--- a/test/plugin.spec.ts
+++ b/test/plugin.spec.ts
@@ -52,4 +52,14 @@ describe("the plugin", () => {
     const input = fixture("elm18_input.js");
     expect(transform(input)).toMatchSnapshot()
   });
+
+  it("custom options work with Elm 0.18", () => {
+    const transform = transformWith(plugin, {
+      package: "user/project",
+      module: "Icon.SvgAsset",
+      function: "svgAsset"
+    });
+    const input = fixture("elm18_module_path_input.js");
+    expect(transform(input)).toMatchSnapshot()
+  });
 });


### PR DESCRIPTION
For example Icon.SvgAsset is processed as `Icon$SvgAsset` in Elm 19,
but `Icon_SvgAsset` in Elm 18.